### PR TITLE
Return only active timetables

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -92,13 +92,12 @@ class TimetableAPIUtils:
     """Contains shared methods for Timetable API functionality."""
 
     def make_api_request_for_timetables(self):
-        query = 'query{timetables{edges{node{name, slug, cycleLength,refCycleDay, \
+        query = 'query{timetables{edges{node{name, slug, cycleLength, refCycleDay, isActive\
                  vendors{edges{node{name}}}, admins{edges{node{username}}}}}}}'
         res = make_api_request(query)
         timetables = res.get('timetables')
-
         if timetables and 'edges' not in timetables:
-            return timetables
+            return [timetable for timetable in timetables if timetable['isActive']]
         else:
             return []
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -101,6 +101,7 @@ class TestAPICalls(TestCase):
                 'slug': 'timetable1',
                 'cycleLength': 5,
                 'refCycleDay': 2,
+                'isActive': True,
                 'vendors': {'edges': []},
                 'admins': {'edges': []}
             }


### PR DESCRIPTION
#36

This PR ensures that only active timetables are returned from the API